### PR TITLE
correcting hover-text for length/weight toggle

### DIFF
--- a/octoprint_cost/templates/cost_settings.jinja2
+++ b/octoprint_cost/templates/cost_settings.jinja2
@@ -23,10 +23,10 @@
       </div>
     </div>
   </div>
-  <div class="control-group" title="Makes OctoPrint try to connect to the printer automatically during start up">
+  <div class="control-group" title="Check this to calculate by length, uncheck for by weight.">
     <div class="controls">
       <label class="checkbox">
-	<input data-bind="checked: check_cost" type="checkbox">Cost per length or weight
+	<input data-bind="checked: check_cost" type="checkbox">Cost per length instead of weight
       </label>
     </div>
   </div>


### PR DESCRIPTION
Settings page had old template text for the length/weight toggle. Corrected the hover text to explain the options and fixed settings text to be more intuitive.