### PR TITLE
Fix description of weight / length calculation checkbox

### DIFF
--- a/octoprint_cost/templates/cost_settings.jinja2
+++ b/octoprint_cost/templates/cost_settings.jinja2
@@ -23,10 +23,10 @@
       </div>
     </div>
   </div>
-  <div class="control-group" title="Check this to calculate by length, uncheck for by weight.">
+  <div class="control-group" title="Check this to calculate by weight, uncheck for length.">
     <div class="controls">
       <label class="checkbox">
-	<input data-bind="checked: check_cost" type="checkbox">Cost per length instead of weight
+	<input data-bind="checked: check_cost" type="checkbox">Calculate cost by weight instead of length
       </label>
     </div>
   </div>


### PR DESCRIPTION
~~As per #15.~~ I misread that issue, this is actually a new issue!

This was bugging me more than it should have, so here's a quick PR to fix it. The correct functionality of this checkbox is that having it checked calculates cost by weight, and having it unchecked calculates cost by length. I thought about changing the logic and leaving this checkbox as is, but a change to the data entry enablers for cost_per_weight and cost_per_length, so this makes more sense.

I've also tweaked the language a little to make it a bit more readable / grammatically correct.